### PR TITLE
Fix README npm install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Aplicación para anotar personas para eventos en el programa BICICACERIA, que es
 
 3. CD a la carpeta `cd bicicaceria`
 
-4. Run `> npm-install` para instalar las dependencias del proyecto
+4. Run `> npm install` para instalar las dependencias del proyecto
 
 5. Instala gulp.js via el terminal de Mac o Gitbash en un PC así: `> npm install -g gulp`
 


### PR DESCRIPTION
## Summary
- replace outdated `npm-install` step with `npm install`
- ensure README ends with a newline

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6841da9ef668832180ee3ecd97e73939